### PR TITLE
Use yamlenv instead of pyyaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.tox/
+.eggs/
+**/__pycache__/
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ params = dict(
     ),
     python_requires='>=2.7',
     install_requires=[
-        'pyyaml',
+        'yamlenv',
         'jaraco.collections!=1.2',
         'six',
     ],

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ params = dict(
     ),
     python_requires='>=2.7',
     install_requires=[
+        'pyyaml',
         'yamlenv',
         'jaraco.collections!=1.2',
         'six',

--- a/vr/launch/config.py
+++ b/vr/launch/config.py
@@ -2,6 +2,7 @@ import os
 import re
 import copy
 import platform
+import warnings
 
 import six
 
@@ -61,6 +62,10 @@ class ConfigDict(jaraco.collections.ItemsAsAttributes, dict):
         >>> d['port_test']
         '5000'
         """
+        warnings.warn(
+            'apply_environment_overrides is deprecated '
+            'in favour of yamlenv environment interpolation',
+            DeprecationWarning)
         environ = self._case_insensitive_environ()
 
         matching_keys = [key for key in self if key in environ]

--- a/vr/launch/config.py
+++ b/vr/launch/config.py
@@ -6,6 +6,7 @@ import platform
 import six
 
 import yaml
+import yamlenv
 import jaraco.collections
 
 
@@ -20,7 +21,12 @@ class ConfigDict(jaraco.collections.ItemsAsAttributes, dict):
 
     @classmethod
     def from_yaml_stream(cls, stream):
-        return cls(yaml.load(stream))
+        """
+        >>> os.environ['PORT_TEST'] = '5000'
+        >>> ConfigDict.from_yaml_stream('port_test: ${PORT_TEST}')
+        {'port_test': '5000'}
+        """
+        return cls(yamlenv.load(stream))
 
     @classmethod
     def from_velociraptor(cls, fallback=None):


### PR DESCRIPTION
yamlenv (https://github.com/lbolla/yamlenv) does `os.environ`
interpolation automatically and it renders obsolete the use of
`apply_environment_overrides` (maintained for compatibility).