### PR TITLE
Require PyYAML version lower than 6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	pyyaml
+	pyyaml<6
 	yamlenv
 	jaraco.collections!=1.2
 	six


### PR DESCRIPTION
PyYAML 6 always require `Loader` arg to `yaml.load()`, which now breaks config module.

See https://github.com/yaml/pyyaml/pull/561.