### PR TITLE
Provide Loader argument to yaml.load() call

### DIFF
--- a/vr/launch/config.py
+++ b/vr/launch/config.py
@@ -27,7 +27,7 @@ class ConfigDict(jaraco.collections.ItemsAsAttributes, dict):
         >>> ConfigDict.from_yaml_stream('port_test: ${PORT_TEST}')
         {'port_test': '5000'}
         """
-        return cls(yamlenv.load(stream))
+        return cls(yamlenv.load(stream, Loader=yaml.Loader))
 
     @classmethod
     def from_velociraptor(cls, fallback=None):


### PR DESCRIPTION
We consider configuration as safe as it comes always from trusted source.
Therefore we can use regular loader.

This commit adds compatibility with PyYAML 6.

Reference:
* https://pyyaml.org/wiki/PyYAMLDocumentation
* https://github.com/yaml/pyyaml/pull/561