### PR TITLE
Revert "Provide Loader argument to yaml.load() call"

### DIFF
--- a/vr/launch/config.py
+++ b/vr/launch/config.py
@@ -27,7 +27,7 @@ class ConfigDict(jaraco.collections.ItemsAsAttributes, dict):
         >>> ConfigDict.from_yaml_stream('port_test: ${PORT_TEST}')
         {'port_test': '5000'}
         """
-        return cls(yamlenv.load(stream, Loader=yaml.Loader))
+        return cls(yamlenv.load(stream))
 
     @classmethod
     def from_velociraptor(cls, fallback=None):


### PR DESCRIPTION
This reverts commit 99273afd036b02c859995e4071785f39e2171edd.

Fixes #5.