### PR TITLE
Fix expectation around interpolation of YAML values from environment variables.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = true
 python_requires = >=2.7
 install_requires =
 	pyyaml
-	yamlenv
+	yamlenv>=0.6
 	jaraco.collections!=1.2
 	six
 setup_requires = setuptools_scm >= 1.15.0

--- a/vr/launch/config.py
+++ b/vr/launch/config.py
@@ -25,7 +25,7 @@ class ConfigDict(jaraco.collections.ItemsAsAttributes, dict):
         """
         >>> os.environ['PORT_TEST'] = '5000'
         >>> ConfigDict.from_yaml_stream('port_test: ${PORT_TEST}')
-        {'port_test': '5000'}
+        {'port_test': 5000}
         """
         return cls(yamlenv.load(stream, Loader=yaml.Loader))
 


### PR DESCRIPTION
- Rely on yamlenv 0.6 and update tests to match that expectation. Fixes #8.
